### PR TITLE
Fixed minor documentation errors

### DIFF
--- a/docs/api.kapi.md
+++ b/docs/api.kapi.md
@@ -127,7 +127,7 @@ Move to a specific millisecond on the timeline and play from there.  `opt_howMan
  * @param {number=} opt_howManyTimes
  * @returns {Kapi}
  */
-Kapi.prototype.playFrom (opt_howManyTimes)
+Kapi.prototype.playFromCurrent (opt_howManyTimes)
 ````
 
 Play from the last frame that was drawn with `render()`. `opt_howManyTimes` works as it does in `play()`.

--- a/docs/api.kapi_actor.md
+++ b/docs/api.kapi_actor.md
@@ -99,7 +99,7 @@ Copy all of the properties that at one point in the timeline to another point. T
  *     until (relative to the start of the animation)
  * @return {Kapi.Actor}
  */
-Kapi.Actor.prototype.copyProperties (when, opt_source)
+Kapi.Actor.prototype.wait (when, opt_source)
 ````
 
 Extend the last state on this `Actor`'s timeline to create a animation wait.  The state does not change during this time.


### PR DESCRIPTION
I noticed that two method names were wrong in the documentation.
