### PR TITLE
Lazily rebuild timelinePropertyCache only when needed

### DIFF
--- a/src/rekapi.actor.js
+++ b/src/rekapi.actor.js
@@ -918,8 +918,8 @@ rekapiModules.push(function (context) {
 
     millisecond = Math.min(endMs, millisecond);
 
-    var latestCacheId = getPropertyCacheIdForMillisecond(this, millisecond);
     ensurePropertyCacheValid(this);
+    var latestCacheId = getPropertyCacheIdForMillisecond(this, millisecond);
     var propertiesToInterpolate =
       this._timelinePropertyCache[this._timelinePropertyCacheKeys[
           latestCacheId]];

--- a/src/rekapi.actor.js
+++ b/src/rekapi.actor.js
@@ -157,10 +157,24 @@ rekapiModules.push(function (context) {
   }
 
   /*!
-   * Empty out and rebuild the cache of internal KeyframeProperty data.
+   * Mark the cache of internal KeyframeProperty data as invalid.  The cache
+   * will be rebuilt on the next call to ensurePropertyCacheValid.
    * @param {Rekapi.Actor}
    */
   function invalidatePropertyCache (actor) {
+    actor._timelinePropertyCacheValid = false;
+  }
+
+  /*!
+   * Empty out and rebuild the cache of internal KeyframeProperty data if it
+   * has been marked as invalid.
+   * @param {Rekapi.Actor}
+   */
+  function ensurePropertyCacheValid (actor) {
+    if (actor._timelinePropertyCacheValid) {
+      return;
+    }
+
     actor._timelinePropertyCache = {};
     var timelinePropertyCache = actor._timelinePropertyCache;
 
@@ -189,6 +203,8 @@ rekapiModules.push(function (context) {
 
     // Re-link the linked list of keyframeProperties
     linkTrackedProperties(actor);
+
+    actor._timelinePropertyCacheValid = true;
   }
 
   /*!
@@ -262,6 +278,7 @@ rekapiModules.push(function (context) {
       '_propertyTracks': {}
       ,'_timelinePropertyCache': {}
       ,'_timelinePropertyCacheKeys': []
+      ,'_timelinePropertyCacheValid': false
       ,'_keyframeProperties': {}
       ,'id': _.uniqueId()
       ,'context': opt_config.context // This may be undefined
@@ -902,6 +919,7 @@ rekapiModules.push(function (context) {
     millisecond = Math.min(endMs, millisecond);
 
     var latestCacheId = getPropertyCacheIdForMillisecond(this, millisecond);
+    ensurePropertyCacheValid(this);
     var propertiesToInterpolate =
       this._timelinePropertyCache[this._timelinePropertyCacheKeys[
           latestCacheId]];

--- a/tests/qunit.actor.html
+++ b/tests/qunit.actor.html
@@ -1256,6 +1256,7 @@
           'x': 100
           ,'y': 100
         });
+      testActor._updateState(0);
 
       var keyPropCount = 0;
 
@@ -1297,6 +1298,8 @@
       testActor.modifyKeyframeProperty('x', 1000, {
         'millisecond': 1500
       });
+
+      testActor._updateState(0);
 
       var keyPropCount = 0;
 

--- a/tests/qunit.to_css.html
+++ b/tests/qunit.to_css.html
@@ -272,6 +272,8 @@
         .keyframe(0,    { 'x': 0   })
         .keyframe(1000, { 'x': 100 }, { 'x': 'fakeLinear' });
 
+      actor1._updateState(0);
+
       var keyframeData = Rekapi._private.cssRenderer.generateBoilerplatedKeyframes(
           actor1, 'ANIM_NAME', 10, false);
 
@@ -307,6 +309,8 @@
         .keyframe(0,    { 'x': 0   })
         .keyframe(1000, { 'x': 100 }, { 'x': 'fakeLinear' });
 
+      actor1._updateState(0);
+
       var keyframeData =
           Rekapi._private.cssRenderer.generateActorKeyframes(actor1, 10, 'x');
 
@@ -338,6 +342,8 @@
       actor1
         .keyframe(0,    { 'x': 0, 'y': 5    })
         .keyframe(1000, { 'x': 100, 'y': 15 }, { 'x': 'fakeLinear' });
+
+      actor1._updateState(0);
 
       var keyframeData =
           Rekapi._private.cssRenderer.generateActorKeyframes(actor1, 10, 'x');
@@ -371,6 +377,8 @@
         .keyframe(500, { y: 5 }, 'fakeLinear')
         .wait(1000);
 
+      actor._updateState(0);
+
       var keyframeData =
           Rekapi._private.cssRenderer.generateActorKeyframes(actor, 10, 'y');
 
@@ -397,6 +405,8 @@
         .keyframe(500, { y: 5 })
         .wait(1000);
 
+      actor._updateState(0);
+
       var keyframeData =
           Rekapi._private.cssRenderer.generateActorKeyframes(actor, 10, 'y');
 
@@ -418,6 +428,8 @@
         .keyframe(0, { transform: 'translateX(0px)' })
         .keyframe(500, { transform: 'translateX(5px)' }, 'fakeLinear')
         .wait(1000);
+
+      actor._updateState(0);
 
       var keyframeData =
           Rekapi._private.cssRenderer.generateActorKeyframes(actor, 10, 'transform');
@@ -473,6 +485,8 @@
         .keyframe(500,  { 'y': 10        }, { 'y': 'fakeLinear' })
         .keyframe(1000, { 'x': 10        }, { 'y': 'fakeLinear' });
 
+      actor1._updateState(0);
+
       var keyframeData =
           Rekapi._private.cssRenderer.generateActorKeyframes(actor1, 10, 'y');
 
@@ -499,6 +513,8 @@
         .keyframe(0,    { 'x': 0   })
         .keyframe(1000, { 'x': 100 }, { 'x': 'fakeLinear' });
 
+      actor1._updateState(0);
+
       var keyframeData =
           Rekapi._private.cssRenderer.generateActorKeyframes(actor1, 100, 'x');
 
@@ -517,6 +533,8 @@
         .keyframe(0,    { 'x': 0  })
         .keyframe(500,  { 'x': 10 })
         .keyframe(1000, { 'x': 20 }, { 'x': 'fakeLinear' });
+
+      actor1._updateState(0);
 
       var keyframeData =
           Rekapi._private.cssRenderer.generateActorKeyframes(actor1, 10, 'x');
@@ -545,6 +563,8 @@
         .keyframe(500,  { 'x': 10 }, { 'x': 'fakeLinear' })
         .keyframe(1000, { 'x': 20 });
 
+      actor1._updateState(0);
+
       var keyframeData =
           Rekapi._private.cssRenderer.generateActorKeyframes(actor1, 10, 'x');
 
@@ -569,6 +589,8 @@
         .keyframe(0,    { 'x': 0  })
         .keyframe(500,  { 'x': 5  })
         .keyframe(1000, { 'x': 10 });
+
+      actor1._updateState(0);
 
       var keyframeData =
           Rekapi._private.cssRenderer.generateActorKeyframes(actor1, 99, 'x');
@@ -1040,6 +1062,8 @@
         .keyframe(0,    { 'x': 0  })
         .keyframe(1000, { 'x': 10 }, { 'x': 'easeInQuad' });
 
+      actor1._updateState(0);
+
       var canBeOptimized = Rekapi._private.cssRenderer.canOptimizeKeyframeProperty(
         actor1.getKeyframeProperty('x', 0));
 
@@ -1078,6 +1102,8 @@
         ,{ 'transform': 'translateX(10) translateY(10)' }
         ,{ 'transform': 'linear linear' });
 
+      actor1._updateState(0);
+
       var canBeOptimized = Rekapi._private.cssRenderer.canOptimizeKeyframeProperty(
         actor1.getKeyframeProperty('transform', 0));
 
@@ -1115,6 +1141,8 @@
         .keyframe(500, { y: 5 })
         .wait(1000);
 
+      actor._updateState(0);
+
       var canBeOptimized = Rekapi._private.cssRenderer.canOptimizeKeyframeProperty(
         actor.getKeyframeProperty('y', 500));
 
@@ -1133,6 +1161,8 @@
         .keyframe(0,    { 'x': 0,  'y': 0  })
         .keyframe(1000, { 'x': 10, 'y': 20 });
 
+      actor1._updateState(0);
+
       var canBeOptimized =
           Rekapi._private.cssRenderer.canOptimizeAnyKeyframeProperties(actor1);
 
@@ -1148,6 +1178,8 @@
       actor1
         .keyframe(0,    { 'x': 0,  'y': 0  })
         .keyframe(1000, { 'x': 10, 'y': 20 }, { 'x': 'fakeLinear' });
+
+      actor1._updateState(0);
 
       var canBeOptimized =
           Rekapi._private.cssRenderer.canOptimizeAnyKeyframeProperties(actor1);
@@ -1186,6 +1218,8 @@
         .keyframe(0,    { 'x': 0  })
         .keyframe(1000, { 'x': 10 }, { 'x': 'easeInQuad' });
 
+      actor1._updateState(0);
+
       var optimizedSegment =
           Rekapi._private.cssRenderer.generateOptimizedKeyframeSegment(
               actor1.getKeyframeProperty('x', 0), 0, 100);
@@ -1207,6 +1241,8 @@
         .keyframe(0,    { 'transform': 'translateX(0)'  })
         .keyframe(1000, { 'transform': 'translateX(10)' }
             ,{ 'transform': 'easeInQuad easeInQuad' });
+
+      actor1._updateState(0);
 
       var optimizedSegment =
           Rekapi._private.cssRenderer.generateOptimizedKeyframeSegment(


### PR DESCRIPTION
This commit avoids an apparent O(n^2) complexity problem when adding
keyframes.  Each keyframe results in the recomputation of the property
cache, which takes an increasing amount of time with the addition of
each keyframe.  Delaying this recomputation until it is required (in
_updateState) changes the page load time for a few hundred keyframes
from around 10 seconds to nearly instant for me.