### PR TITLE
RFC/strawman: Actor activation

### DIFF
--- a/renderers/canvas/rekapi.renderer.canvas.js
+++ b/renderers/canvas/rekapi.renderer.canvas.js
@@ -59,7 +59,9 @@ rekapiModules.push(function (context) {
     var i;
     for (i = 0; i < len; i++) {
       currentActor = canvasActors[renderOrder[i]];
-      currentActor.render(currentActor.context, currentActor.get());
+      if (currentActor.wasActive) {
+        currentActor.render(currentActor.context, currentActor.get());
+      }
     }
     fireEvent(rekapi, 'afterRender', _);
 

--- a/renderers/canvas/rekapi.renderer.canvas.js
+++ b/renderers/canvas/rekapi.renderer.canvas.js
@@ -158,6 +158,7 @@ rekapiModules.push(function (context) {
     this._renderOrder = [];
     this._renderOrderSorter = null;
     this._canvasActors = {};
+    this._batchRendering = true;
 
     _.extend(rekapi._events, {
       'beforeRender': []

--- a/src/rekapi.actor.js
+++ b/src/rekapi.actor.js
@@ -895,11 +895,11 @@ rekapiModules.push(function (context) {
   /*!
    * Set the actor to be active or inactive starting at `millisecond`.
    * @method setActive
-   * @param {boolean} isActive Whether the actor should be active or inactive
    * @param {number} millisecond The time at which to change the actor's active state
+   * @param {boolean} isActive Whether the actor should be active or inactive
    * @chainable
    */
-  Actor.prototype.setActive = function (isActive, millisecond) {
+  Actor.prototype.setActive = function (millisecond, isActive) {
     var activeProperty = this._propertyTracks._active
         && this.getKeyframeProperty('_active', millisecond);
 

--- a/src/rekapi.actor.js
+++ b/src/rekapi.actor.js
@@ -39,7 +39,7 @@ rekapiModules.push(function (context) {
    * @param {Rekapi.Actor} actor
    * @param {number} millisecond
    * @return {Object|undefined} undefined if there is no property cache for
-   * the millisecond (this should never happen).
+   * the millisecond, i.e. an empty cache.
    */
   function getPropertyCacheEntryForMillisecond (actor, millisecond) {
     var cache = actor._timelinePropertyCache;
@@ -56,8 +56,6 @@ rekapiModules.push(function (context) {
     } else if (index >= 1) {
       return cache[index - 1];
     }
-
-    return -1;
   }
 
   /*!

--- a/src/rekapi.core.js
+++ b/src/rekapi.core.js
@@ -591,7 +591,7 @@ var rekapiCore = function (root, _, Tweenable) {
     // Update and render each of the actors
     _.each(this._actors, function (actor) {
       actor._updateState(opt_millisecond, opt_doResetLaterFnKeyframes);
-      if (!skipRender && typeof actor.render === 'function') {
+      if (!skipRender && actor.wasActive && typeof actor.render === 'function') {
         actor.render(actor.context, actor.get());
       }
     });

--- a/src/rekapi.core.js
+++ b/src/rekapi.core.js
@@ -580,6 +580,8 @@ var rekapiCore = function (root, _, Tweenable) {
    * @chainable
    */
   Rekapi.prototype.update = function (opt_millisecond,  opt_doResetLaterFnKeyframes) {
+    var skipRender = this.renderer && this.renderer._batchRendering;
+
     if (opt_millisecond === undefined) {
       opt_millisecond = this._lastUpdatedMillisecond;
     }
@@ -589,7 +591,7 @@ var rekapiCore = function (root, _, Tweenable) {
     // Update and render each of the actors
     _.each(this._actors, function (actor) {
       actor._updateState(opt_millisecond, opt_doResetLaterFnKeyframes);
-      if (typeof actor.render === 'function') {
+      if (!skipRender && typeof actor.render === 'function') {
         actor.render(actor.context, actor.get());
       }
     });

--- a/src/rekapi.keyframe-property.js
+++ b/src/rekapi.keyframe-property.js
@@ -81,7 +81,9 @@ rekapiModules.push(function (context) {
     var nextProperty = this.nextProperty;
     var correctedMillisecond = Math.max(millisecond, this.millisecond);
 
-    if (nextProperty) {
+    if (typeof this.value === 'boolean') {
+      value = this.value;
+    } else if (nextProperty) {
       correctedMillisecond =
       Math.min(correctedMillisecond, nextProperty.millisecond);
 

--- a/tests/qunit.actor.html
+++ b/tests/qunit.actor.html
@@ -275,6 +275,42 @@
           'Keyframe 0 for Y was implicitly defined and tweened against');
     });
 
+    test('Only updates actors when active',
+      function () {
+
+      var testRekapi
+          ,testActor;
+
+      testRekapi = setupTestRekapi();
+      testActor = setupTestActor(testRekapi);
+
+      testActor.keyframe(0,{
+        'x': 0
+      })
+      .setActive(false, 250)
+      .setActive(true, 750)
+      .keyframe(1000, {
+        'x': 100
+      });
+
+      testActor._updateState(100);
+      var active100 = testActor.wasActive;
+      var x100 = testActor.get().x;
+      testActor._updateState(500);
+      var active500 = testActor.wasActive;
+      var x500 = testActor.get().x;
+      testActor._updateState(900);
+      var active900 = testActor.wasActive;
+      var x900 = testActor.get().x;
+
+      equal(active100, true, 'Actor was active at 100ms.');
+      equal(x100, 10, 'x was updated at 100ms.');
+      equal(active500, false, 'Actor was not active at 500ms.');
+      equal(x500, 10, 'x was not updated at 500ms.');
+      equal(active900, true, 'Actor was active at 900ms.');
+      equal(x900, 90, 'x was updated at 900ms.');
+    });
+
 
     module('_addKeyframeProperty');
 

--- a/tests/qunit.actor.html
+++ b/tests/qunit.actor.html
@@ -287,8 +287,8 @@
       testActor.keyframe(0,{
         'x': 0
       })
-      .setActive(false, 250)
-      .setActive(true, 750)
+      .setActive(250, false)
+      .setActive(750, true)
       .keyframe(1000, {
         'x': 100
       });


### PR DESCRIPTION
Apologies for the inclusion of all the optimization commits; I tried to get Github to let me make a pull request based on top of my other one, but the only way it would let me do that is if the PR was for my fork.  The first commit in this PR is `Allow 'tweening' of booleans`

Not calling render for inactive actors does the right thing if you're using a canvas renderer and if you're clearing it between each update, otherwise it might have unexpected effects.  I'm not sure at all what an inactive actor would do to the DOM renderer, I've never used that.

Note also the batch rendering change; I think this is the right thing to do.  Certainly rendering everything twice seems wrongish.