### PR TITLE
Warnings/Errors for common keyframe screwups

### DIFF
--- a/src/rekapi.actor.js
+++ b/src/rekapi.actor.js
@@ -882,6 +882,15 @@ rekapiModules.push(function (context) {
       }
     } else {
       var index = insertionPointInTrack(propertyTracks[name], keyframeProperty.millisecond);
+      if (propertyTracks[name][index]) {
+        var ms = keyframeProperty.millisecond;
+        var otherMs = propertyTracks[name][index].millisecond;
+        if (otherMs === ms) {
+          throw new Error('Tried to add a duplicate keyframe property, '+name+' @ '+ms+' ms');
+        } else if (this.rekapi && this.rekapi._warnOnOutOfOrderKeyframes) {
+          console.warn(new Error('Added a keyframe property before end of track, '+name+' @ '+ms+' ms < '+otherMs+' ms'));
+        }
+      }
       this._insertKeyframePropertyAt(keyframeProperty, propertyTracks[name], index);
     }
 


### PR DESCRIPTION
Duplicate keyframes always cause an error as they break playback.  Set
`rekapi._warnOnOutOfOrderKeyframes` to warn on out-of-order keyframe
assignments (i.e. before the last one on the track) as this can indicate
a keyframe overlap that can cause strange animation effects if not
planned for.  `new Error` is used even in the warning case to provide
a backtrace.