### PR TITLE
Correct gPCEFMillisecond to always work for times < first keyframe

### DIFF
--- a/src/rekapi.actor.js
+++ b/src/rekapi.actor.js
@@ -44,17 +44,14 @@ rekapiModules.push(function (context) {
   function getPropertyCacheEntryForMillisecond (actor, millisecond) {
     var cache = actor._timelinePropertyCache;
 
-    // If there is only one keyframe, use that
-    if (cache.length === 1) {
-      return cache[0];
-    }
-
     var index = _.sortedIndex(cache, { _millisecond: millisecond }, get_Millisecond);
 
     if (cache[index] && cache[index]._millisecond === millisecond) {
       return cache[index];
     } else if (index >= 1) {
       return cache[index - 1];
+    } else {
+      return cache[0];
     }
   }
 


### PR DESCRIPTION
I had wanted to restructure this as such when I did the comment/return
fix, but incorrectly decided on the other path to reduce potential
breakage.  The only reason it was working before was that `-1` was
something that you could pull properties out of, even though it is
distinctly not a cache entry.

This will still cause an error if the timeline is empty.