### PR TITLE
Suggested change.

### DIFF
--- a/renderers/dom/rekapi.renderer.dom.js
+++ b/renderers/dom/rekapi.renderer.dom.js
@@ -1230,14 +1230,16 @@ const combineTranfromProperties = (propsToSerialize, transformNames) => {
  * @return {string}
  */
 const serializeActorStep = (actor, targetProp = undefined) =>
-  _.reduce(
+  JSON.stringify(_.reduce(
     combineTranfromProperties(
       targetProp ? { [targetProp]: actor.get()[targetProp] } : actor.get(),
       actor._transformOrder
     ),
-    (serializedProps, val, key) =>
-      `${serializedProps}${key === 'transform' ? TRANSFORM_TOKEN : key}:${val};`,
-    '{') + '}';
+    (serializedProps, val, key) => {
+      serializedProps[key === 'transform' ? TRANSFORM_TOKEN : key] = val;
+      return serializedProps;
+    },
+    {}));
 
 // Expose helper functions for unit testing.
 // FIXME: Don't include this in optimized builds.


### PR DESCRIPTION
Hand-cratfting JSON is wrought with peril, since escaping of quotes and
other special characters is just tricky.

In addition, using `JSON.stringify` makes it a little more explicit that
that's what you're doing.