### PR TITLE
adding support for array custom easing

### DIFF
--- a/src/actor.js
+++ b/src/actor.js
@@ -332,7 +332,7 @@ export class Actor extends Tweenable {
           millisecond,
           name,
           value,
-          typeof easing === 'string' ?
+          typeof easing === 'string' || Array.isArray(easing) ?
             easing :
             (easing[name] || DEFAULT_EASING)
         )


### PR DESCRIPTION
This PR enables the usage of arrays (bezier curves) to create custom easinging, eliminating the need to generate a named function for the custom easings, which therefore allows the usage of graph/curve editors to customize the easings furthermore. Such arrays must be of length 4 such as the following: `[0.755, 0.05, 0.855, 0.06]`

Further tests might be needed to make sure the import and export of the timeline works seamlessly, the initial tests from my side has worked so far.