### PR TITLE
Upgrade on-headers and morgan dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,10 @@
         "jshint": "^2.9.4",
         "live-server": "^1.2.0",
         "lodash": "^4.17.21",
+        "morgan": "^1.10.1",
         "node-abort-controller": "^1.1.0",
         "nodemon": "^3.1.10",
+        "on-headers": "^1.1.0",
         "vite": "^7.0.6",
         "vitest": "^4.1.8"
       }
@@ -4318,9 +4320,9 @@
       }
     },
     "node_modules/morgan": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
+      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4328,7 +4330,7 @@
         "debug": "2.6.9",
         "depd": "~2.0.0",
         "on-finished": "~2.3.0",
-        "on-headers": "~1.0.2"
+        "on-headers": "~1.1.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -4815,9 +4817,9 @@
       }
     },
     "node_modules/on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9898,16 +9900,16 @@
       }
     },
     "morgan": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
-      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
+      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
       "dev": true,
       "requires": {
         "basic-auth": "~2.0.1",
         "debug": "2.6.9",
         "depd": "~2.0.0",
         "on-finished": "~2.3.0",
-        "on-headers": "~1.0.2"
+        "on-headers": "~1.1.0"
       }
     },
     "ms": {
@@ -10240,9 +10242,9 @@
       }
     },
     "on-headers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
       "dev": true
     },
     "once": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,10 +23,8 @@
         "jshint": "^2.9.4",
         "live-server": "^1.2.0",
         "lodash": "^4.17.21",
-        "morgan": "^1.10.1",
         "node-abort-controller": "^1.1.0",
         "nodemon": "^3.1.10",
-        "on-headers": "^1.1.0",
         "vite": "^7.0.6",
         "vitest": "^4.1.8"
       }
@@ -9678,7 +9676,7 @@
         "event-stream": "3.3.4",
         "faye-websocket": "0.11.x",
         "http-auth": "3.1.x",
-        "morgan": "^1.9.1",
+        "morgan": "^1.10.1",
         "object-assign": "latest",
         "opn": "latest",
         "proxy-middleware": "latest",
@@ -9909,7 +9907,7 @@
         "debug": "2.6.9",
         "depd": "~2.0.0",
         "on-finished": "~2.3.0",
-        "on-headers": "~1.1.0"
+        "on-headers": "^1.1.0"
       }
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
       "name": "Brian Downing"
     }
   ],
+  "overrides": {
+    "morgan": "^1.10.1",
+    "on-headers": "^1.1.0"
+  },
   "devDependencies": {
     "@jeremyckahn/minami": "^1.3.1",
     "c8": "^7.11.3",
@@ -23,10 +27,8 @@
     "jshint": "^2.9.4",
     "live-server": "^1.2.0",
     "lodash": "^4.17.21",
-    "morgan": "^1.10.1",
     "node-abort-controller": "^1.1.0",
     "nodemon": "^3.1.10",
-    "on-headers": "^1.1.0",
     "vite": "^7.0.6",
     "vitest": "^4.1.8"
   },

--- a/package.json
+++ b/package.json
@@ -23,8 +23,10 @@
     "jshint": "^2.9.4",
     "live-server": "^1.2.0",
     "lodash": "^4.17.21",
+    "morgan": "^1.10.1",
     "node-abort-controller": "^1.1.0",
     "nodemon": "^3.1.10",
+    "on-headers": "^1.1.0",
     "vite": "^7.0.6",
     "vitest": "^4.1.8"
   },


### PR DESCRIPTION
Upgraded `morgan` to `^1.10.1` and `on-headers` to `^1.1.0` in `package.json` to override the older versions previously resolved by transitive dependencies. Also updated `package-lock.json`. Tests are passing.

---
*PR created automatically by Jules for task [10392956201396669487](https://jules.google.com/task/10392956201396669487) started by @jeremyckahn*